### PR TITLE
Handle DOM availability when constructing ERCanvas

### DIFF
--- a/src/facade/ERCanvas.js
+++ b/src/facade/ERCanvas.js
@@ -19,10 +19,19 @@ export class ERCanvas extends EventEmitter {
   constructor(containerOrCanvas, options = {}) {
     super();
     this.options = options;
-    this.container = containerOrCanvas instanceof HTMLCanvasElement ? containerOrCanvas : null;
+    const hasHTMLCanvas = typeof HTMLCanvasElement !== 'undefined';
+    const hasHTMLElement = typeof HTMLElement !== 'undefined';
+    const isCanvas = hasHTMLCanvas && containerOrCanvas instanceof HTMLCanvasElement;
+    const isElement = hasHTMLElement && containerOrCanvas instanceof HTMLElement;
+
+    this.container = isCanvas ? containerOrCanvas : null;
     if (!this.container) {
+      if (typeof document === 'undefined') {
+        throw new Error('ERCanvas requires a DOM environment with document available');
+      }
+
       this.container = document.createElement('canvas');
-      if (containerOrCanvas instanceof HTMLElement) {
+      if (isElement) {
         containerOrCanvas.appendChild(this.container);
       } else {
         throw new Error('ERCanvas requires a canvas or container element');


### PR DESCRIPTION
## Summary
- avoid referencing DOM globals when running outside of a browser
- provide a clearer error when ERCanvas is created without a DOM

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e37733a6148324bc70812c912d85d7