### PR TITLE
Fix basic example to avoid CORS error

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -23,8 +23,9 @@
   </head>
   <body>
     <div id="app"></div>
-    <script type="module">
-      import { ERCanvas } from '../src/index.js';
+    <script src="../dist/er-canvas.umd.js"></script>
+    <script>
+      const { ERCanvas } = ERCanvasLib;
 
       const container = document.getElementById('app');
       const er = new ERCanvas(container, {


### PR DESCRIPTION
## Summary
- update the basic example to load the prebuilt UMD bundle instead of the ESM source
- avoid CORS issues when opening the example directly from the file system

## Testing
- not run (example change only)

------
https://chatgpt.com/codex/tasks/task_e_68e3795860748324ab27df4052e8f7b3