### PR TITLE
Add Docker configuration for serving ER canvas examples

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --omit=dev
+
+COPY . .
+
+EXPOSE 8080
+CMD ["node", "docker/static-server.mjs"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  er-canvas:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - PORT=8080
+      - DEFAULT_FILE=examples/basic.html
+      - STATIC_ROOT=.
+    restart: unless-stopped

--- a/docker/static-server.mjs
+++ b/docker/static-server.mjs
@@ -1,0 +1,90 @@
+import { createServer } from 'http';
+import { readFile, stat } from 'fs/promises';
+import { extname, join, normalize } from 'path';
+
+const PORT = Number.parseInt(process.env.PORT ?? '8080', 10);
+const DEFAULT_FILE = process.env.DEFAULT_FILE ?? 'examples/basic.html';
+const ROOT = join(process.cwd(), process.env.STATIC_ROOT ?? '.');
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+};
+
+function resolvePath(requestPath) {
+  const cleaned = requestPath.replace(/^\/+/, '');
+  if (!cleaned) {
+    return DEFAULT_FILE;
+  }
+  return cleaned;
+}
+
+async function fileExists(filePath) {
+  try {
+    const fileStat = await stat(filePath);
+    if (fileStat.isDirectory()) {
+      return fileExists(join(filePath, 'index.html'));
+    }
+    return filePath;
+  } catch (error) {
+    return null;
+  }
+}
+
+function getContentType(filePath) {
+  const ext = extname(filePath).toLowerCase();
+  return mimeTypes[ext] ?? 'application/octet-stream';
+}
+
+function isPathWithinRoot(filePath) {
+  const normalizedRoot = normalize(ROOT + '/');
+  const normalizedPath = normalize(filePath);
+  return normalizedPath.startsWith(normalizedRoot);
+}
+
+const server = createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    const resolvedPath = resolvePath(decodeURIComponent(url.pathname));
+    const absolutePath = normalize(join(ROOT, resolvedPath));
+
+    if (!isPathWithinRoot(absolutePath)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Forbidden');
+      return;
+    }
+
+    const existingFile = await fileExists(absolutePath);
+    if (!existingFile) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+      return;
+    }
+
+    const content = await readFile(existingFile);
+    res.writeHead(200, {
+      'Content-Type': getContentType(existingFile),
+      'Cache-Control': 'no-store',
+    });
+    res.end(content);
+  } catch (error) {
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Internal Server Error');
+    console.error(error);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Static server listening on port ${PORT}`);
+  console.log(`Serving files from ${ROOT}`);
+  console.log(`Default file: ${DEFAULT_FILE}`);
+});

--- a/readme.txt
+++ b/readme.txt
@@ -37,3 +37,18 @@ Key capabilities exposed by `ERCanvas` include:
 The source files are authored as ES modules and can be consumed directly in modern browsers. Optional build scripts can be added for packaging (`package.json` contains placeholders for bundling and testing).
 
 Start the basic example by serving the repository with any static file server and navigating to `examples/basic.html` in a modern browser.
+
+## Docker usage
+
+This repository includes a Docker setup under the `docker/` directory that serves the static examples from inside a container. To run it locally:
+
+1. Build and start the container with Docker Compose:
+
+   ```bash
+   cd docker
+   docker compose up --build
+   ```
+
+2. Open <http://localhost:8080/examples/basic.html> in your browser to access the demo.
+
+Environment variables exposed in `docker/docker-compose.yml` let you customize the port, default file, and static root if needed.


### PR DESCRIPTION
## Summary
- add a Docker image and docker-compose setup that serves the repository files through a simple Node static server
- document how to run the containerized example in the project README

## Testing
- `node docker/static-server.mjs & sleep 1 && curl -I http://127.0.0.1:8080/examples/basic.html`


------
https://chatgpt.com/codex/tasks/task_e_68e37b15b5348324866c947396f0dd8f