### PR TITLE
Add Yjs collaboration plugin and example

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -61,3 +61,25 @@ er.on('selection:change', (selection) => {
 ```
 
 See `examples/basic.html` for a runnable example.
+
+## Collaborative editing with Yjs
+
+You can synchronize diagrams between multiple browser sessions by combining ERCanvas with
+the [`createYjsSyncPlugin`](../src/plugins/createYjsSyncPlugin.js) helper and any Yjs
+provider. The snippet below connects to a shared room using `y-webrtc`:
+
+```js
+import * as Y from 'yjs';
+import { WebrtcProvider } from 'y-webrtc';
+import { ERCanvas, createYjsSyncPlugin } from 'er-canvas';
+
+const doc = new Y.Doc();
+const provider = new WebrtcProvider('room-name', doc);
+
+ERCanvas.use(createYjsSyncPlugin({ doc, provider }));
+
+const er = new ERCanvas(canvasElement);
+```
+
+Once the plugin is registered every table, field, and edge mutation is mirrored to the Yjs
+document. Open `examples/collaborative.html` in two browser tabs to try the full workflow.

--- a/examples/collaborative.html
+++ b/examples/collaborative.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>ERCanvas Collaborative Example</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        background: #0f1115;
+        color: #e9edf5;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        display: grid;
+        grid-template-columns: 280px 1fr;
+        height: 100vh;
+      }
+      aside {
+        padding: 24px;
+        border-right: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(12, 15, 22, 0.85);
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+      aside h1 {
+        margin: 0;
+        font-size: 1.4rem;
+      }
+      aside p {
+        margin: 0;
+        line-height: 1.4;
+        font-size: 0.95rem;
+      }
+      #status {
+        font-size: 0.85rem;
+        opacity: 0.8;
+      }
+      #app {
+        position: relative;
+        height: 100%;
+      }
+      canvas {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        display: block;
+      }
+      code {
+        font-family: 'Fira Code', 'SFMono-Regular', ui-monospace, monospace;
+        background: rgba(255, 255, 255, 0.08);
+        padding: 2px 4px;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <aside>
+      <h1>Collaborative ER Diagram</h1>
+      <p>
+        This example uses <a href="https://docs.yjs.dev/" target="_blank" rel="noreferrer">Yjs</a>
+        with the <code>createYjsSyncPlugin</code> helper to synchronize diagrams across
+        connected peers. Open this page in a second browser tab (or share the URL) to
+        collaborate in real time.
+      </p>
+      <p id="status">Connecting…</p>
+      <p>
+        Try dragging tables, renaming them, or adding/removing fields. All changes are
+        shared with every tab connected to the same room.
+      </p>
+    </aside>
+    <div id="app"></div>
+    <script type="module">
+      import { ERCanvas, createYjsSyncPlugin } from '../src/index.js';
+      import * as Y from 'https://cdn.jsdelivr.net/npm/yjs@13.6.12/+esm';
+      import { WebrtcProvider } from 'https://cdn.jsdelivr.net/npm/y-webrtc@10.3.8/+esm';
+
+      const ROOM_NAME = 'er-canvas-collaborative-example';
+      const doc = new Y.Doc();
+      const provider = new WebrtcProvider(ROOM_NAME, doc, {
+        signaling: ['wss://signaling.yjs.dev'],
+      });
+
+      const statusEl = document.getElementById('status');
+      provider.on('status', (event) => {
+        statusEl.textContent = event.status === 'connected' ? 'Connected to peers' : 'Connecting…';
+      });
+
+      ERCanvas.use(
+        createYjsSyncPlugin({
+          doc,
+          provider,
+          mapName: 'demo-diagram',
+        })
+      );
+
+      const container = document.getElementById('app');
+      const er = new ERCanvas(container, {
+        grid: { enabled: true, size: 32, snap: true },
+      });
+      er.start();
+
+      if (er.scene.tables.size === 0) {
+        const usersId = er.addTable({
+          id: 'Users',
+          name: 'Users',
+          position: { x: -220, y: -40 },
+          size: { width: 240 },
+          fields: [
+            { id: 'id', name: 'id', type: 'uuid', isPrimaryKey: true },
+            { id: 'email', name: 'email', type: 'text', isUnique: true },
+            { id: 'created_at', name: 'created_at', type: 'timestamp' },
+          ],
+        });
+
+        const postsId = er.addTable({
+          id: 'Posts',
+          name: 'Posts',
+          position: { x: 180, y: 20 },
+          size: { width: 240 },
+          fields: [
+            { id: 'id', name: 'id', type: 'uuid', isPrimaryKey: true },
+            { id: 'user_id', name: 'user_id', type: 'uuid', isForeignKey: true },
+            { id: 'title', name: 'title', type: 'text' },
+            { id: 'published_at', name: 'published_at', type: 'timestamp' },
+          ],
+        });
+
+        er.connect({
+          id: 'UserPosts',
+          from: { tableId: usersId, fieldId: 'id' },
+          to: { tableId: postsId, fieldId: 'user_id' },
+          cardinality: { from: '1', to: 'N' },
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/readme.txt
+++ b/readme.txt
@@ -24,6 +24,8 @@ dist/             // prebuilt entry points (ESM and UMD bundles + type defs)
 
 See `examples/basic.html` for a complete example that instantiates `ERCanvas`, creates two tables, connects them, and listens to selection events.
 
+For real-time collaboration, the library exposes a `createYjsSyncPlugin` helper that wires ERCanvas to a [Yjs](https://docs.yjs.dev) document. Combining the plugin with a provider such as `y-webrtc` keeps diagram edits synchronized across multiple browser sessions. A ready-to-run demonstration is available in `examples/collaborative.html`.
+
 Key capabilities exposed by `ERCanvas` include:
 
 - Scene graph mutations via `addTable`, `addField`, `connect`, `removeTable`, etc.

--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,4 @@ export { DEFAULT_THEME } from './render/Theme.js';
 export { TableNode } from './model/TableNode.js';
 export { Field } from './model/Field.js';
 export { Edge } from './model/Edge.js';
+export { createYjsSyncPlugin } from './plugins/createYjsSyncPlugin.js';

--- a/src/plugins/createYjsSyncPlugin.js
+++ b/src/plugins/createYjsSyncPlugin.js
@@ -1,0 +1,116 @@
+const DEFAULT_MAP_NAME = 'er-canvas';
+const DEFAULT_SCENE_KEY = 'scene';
+
+/**
+ * Creates a plugin that synchronizes ERCanvas state with a Yjs document.
+ *
+ * Usage:
+ * ```js
+ * import * as Y from 'yjs';
+ * import { WebrtcProvider } from 'y-webrtc';
+ * import { ERCanvas, createYjsSyncPlugin } from 'er-canvas';
+ *
+ * const doc = new Y.Doc();
+ * const provider = new WebrtcProvider('room-name', doc);
+ * ERCanvas.use(createYjsSyncPlugin({ doc, provider }));
+ * ```
+ */
+export function createYjsSyncPlugin({
+  doc,
+  mapName = DEFAULT_MAP_NAME,
+  sceneKey = DEFAULT_SCENE_KEY,
+  provider,
+  onSynced,
+} = {}) {
+  if (!doc || typeof doc.getMap !== 'function') {
+    throw new Error('createYjsSyncPlugin requires a Y.Doc instance via the "doc" option');
+  }
+
+  return ({ er }) => {
+    const sharedMap = doc.getMap(mapName);
+    const cleanup = [];
+    let isApplyingRemote = false;
+    let isPushingLocal = false;
+
+    const serializeScene = () => JSON.stringify(er.toJSON());
+
+    const applySharedState = () => {
+      const snapshot = sharedMap.get(sceneKey);
+      if (typeof snapshot !== 'string') return;
+      isApplyingRemote = true;
+      try {
+        const data = JSON.parse(snapshot);
+        er.fromJSON(data);
+        er.renderer.drawFrame();
+        if (typeof onSynced === 'function') {
+          onSynced({ source: 'remote', data });
+        }
+      } catch (err) {
+        console.warn('Yjs sync: failed to apply remote scene', err);
+      } finally {
+        isApplyingRemote = false;
+      }
+    };
+
+    const pushLocalState = () => {
+      if (isApplyingRemote) return;
+      isPushingLocal = true;
+      try {
+        const serialized = serializeScene();
+        if (sharedMap.get(sceneKey) !== serialized) {
+          sharedMap.set(sceneKey, serialized);
+        }
+        if (typeof onSynced === 'function') {
+          onSynced({ source: 'local', data: er.toJSON() });
+        }
+      } finally {
+        isPushingLocal = false;
+      }
+    };
+
+    const observer = () => {
+      if (isPushingLocal) return;
+      applySharedState();
+    };
+
+    sharedMap.observe(observer);
+
+    if (provider && typeof provider.connect === 'function' && provider.shouldConnect !== false) {
+      provider.connect();
+    }
+
+    if (!sharedMap.has(sceneKey)) {
+      pushLocalState();
+    } else {
+      applySharedState();
+    }
+
+    const syncEvents = [
+      'table:add',
+      'table:update',
+      'table:remove',
+      'field:add',
+      'field:update',
+      'field:remove',
+      'field:reorder',
+      'edge:add',
+      'edge:update',
+      'edge:remove',
+      'scene:load',
+    ];
+
+    syncEvents.forEach((eventName) => {
+      cleanup.push(er.on(eventName, pushLocalState));
+    });
+
+    const originalDestroy = er.destroy.bind(er);
+    er.destroy = () => {
+      sharedMap.unobserve(observer);
+      cleanup.forEach((off) => off());
+      if (provider && typeof provider.disconnect === 'function') {
+        provider.disconnect();
+      }
+      originalDestroy();
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable createYjsSyncPlugin helper to synchronize ERCanvas with a Yjs document
- document the new collaboration workflow and expose the plugin from the public index
- add a collaborative example using y-webrtc so multiple tabs edit the same ER diagram

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5ffb21d548324b441c17c24334aa2