### PR TITLE
Fix collaborative example to work without HTTP server

### DIFF
--- a/dist/er-canvas.d.ts
+++ b/dist/er-canvas.d.ts
@@ -45,6 +45,16 @@ export interface DiagramJSON {
   grid?: any;
 }
 
+export interface YjsSyncPluginOptions {
+  doc: any;
+  mapName?: string;
+  sceneKey?: string;
+  provider?: { connect?: () => void; disconnect?: () => void; shouldConnect?: boolean } | null;
+  onSynced?: (payload: { source: 'local' | 'remote'; data: DiagramJSON }) => void;
+}
+
+export declare function createYjsSyncPlugin(options: YjsSyncPluginOptions): (context: { er: ERCanvas }) => void;
+
 export interface ERCanvasOptions {
   width?: number | 'auto';
   height?: number | 'auto';

--- a/dist/er-canvas.umd.js
+++ b/dist/er-canvas.umd.js
@@ -1225,11 +1225,115 @@
     }
   }
 
+  const DEFAULT_MAP_NAME = 'er-canvas';
+  const DEFAULT_SCENE_KEY = 'scene';
+
+  function createYjsSyncPlugin({
+    doc,
+    mapName = DEFAULT_MAP_NAME,
+    sceneKey = DEFAULT_SCENE_KEY,
+    provider,
+    onSynced,
+  } = {}) {
+    if (!doc || typeof doc.getMap !== 'function') {
+      throw new Error('createYjsSyncPlugin requires a Y.Doc instance via the "doc" option');
+    }
+
+    return ({ er }) => {
+      const sharedMap = doc.getMap(mapName);
+      const cleanup = [];
+      let isApplyingRemote = false;
+      let isPushingLocal = false;
+
+      const serializeScene = () => JSON.stringify(er.toJSON());
+
+      const applySharedState = () => {
+        const snapshot = sharedMap.get(sceneKey);
+        if (typeof snapshot !== 'string') return;
+        isApplyingRemote = true;
+        try {
+          const data = JSON.parse(snapshot);
+          er.fromJSON(data);
+          er.renderer.drawFrame();
+          if (typeof onSynced === 'function') {
+            onSynced({ source: 'remote', data });
+          }
+        } catch (err) {
+          console.warn('Yjs sync: failed to apply remote scene', err);
+        } finally {
+          isApplyingRemote = false;
+        }
+      };
+
+      const pushLocalState = () => {
+        if (isApplyingRemote) return;
+        isPushingLocal = true;
+        try {
+          const serialized = serializeScene();
+          if (sharedMap.get(sceneKey) !== serialized) {
+            sharedMap.set(sceneKey, serialized);
+          }
+          if (typeof onSynced === 'function') {
+            onSynced({ source: 'local', data: er.toJSON() });
+          }
+        } finally {
+          isPushingLocal = false;
+        }
+      };
+
+      const observer = () => {
+        if (isPushingLocal) return;
+        applySharedState();
+      };
+
+      sharedMap.observe(observer);
+
+      if (provider && typeof provider.connect === 'function' && provider.shouldConnect !== false) {
+        provider.connect();
+      }
+
+      if (!sharedMap.has(sceneKey)) {
+        pushLocalState();
+      } else {
+        applySharedState();
+      }
+
+      const syncEvents = [
+        'table:add',
+        'table:update',
+        'table:remove',
+        'field:add',
+        'field:update',
+        'field:remove',
+        'field:reorder',
+        'edge:add',
+        'edge:update',
+        'edge:remove',
+        'scene:load',
+      ];
+
+      syncEvents.forEach((eventName) => {
+        cleanup.push(er.on(eventName, pushLocalState));
+      });
+
+      const originalDestroy = er.destroy.bind(er);
+      er.destroy = () => {
+        sharedMap.unobserve(observer);
+        cleanup.forEach((off) => off());
+        if (provider && typeof provider.disconnect === 'function') {
+          provider.disconnect();
+        }
+        originalDestroy();
+      };
+    };
+  }
+
   return {
     ERCanvas,
     DEFAULT_THEME,
     TableNode,
     Field,
     Edge,
+    createYjsSyncPlugin,
   };
 });

--- a/examples/collaborative.html
+++ b/examples/collaborative.html
@@ -72,10 +72,12 @@
       </p>
     </aside>
     <div id="app"></div>
+    <script src="../dist/er-canvas.umd.js"></script>
     <script type="module">
-      import { ERCanvas, createYjsSyncPlugin } from '../src/index.js';
       import * as Y from 'https://cdn.jsdelivr.net/npm/yjs@13.6.12/+esm';
       import { WebrtcProvider } from 'https://cdn.jsdelivr.net/npm/y-webrtc@10.3.8/+esm';
+
+      const { ERCanvas, createYjsSyncPlugin } = ERCanvasLib;
 
       const ROOM_NAME = 'er-canvas-collaborative-example';
       const doc = new Y.Doc();


### PR DESCRIPTION
## Summary
- expose the createYjsSyncPlugin helper from the UMD bundle so it is available in browser globals
- extend the published type definitions with the plugin options and signature
- update the collaborative example to load the bundled script instead of importing from src to avoid file:// CORS issues

## Testing
- node scripts/test-runner.js

------
https://chatgpt.com/codex/tasks/task_e_68e6095a701c832486de37bb25351223