### PR TITLE
Add collaborative docker compose with local signaling server

### DIFF
--- a/docker/Dockerfile.signaling
+++ b/docker/Dockerfile.signaling
@@ -1,0 +1,9 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+RUN npm install y-webrtc@10.3.0
+
+EXPOSE 4444
+
+CMD ["node", "node_modules/y-webrtc/bin/server.js", "--port", "4444"]

--- a/docker/docker-compose.collaborative.yml
+++ b/docker/docker-compose.collaborative.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  er-canvas:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - PORT=8080
+      - DEFAULT_FILE=examples/collaborative.html
+      - STATIC_ROOT=.
+    depends_on:
+      - signaling
+    restart: unless-stopped
+
+  signaling:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.signaling
+    ports:
+      - "4444:4444"
+    restart: unless-stopped

--- a/examples/collaborative.html
+++ b/examples/collaborative.html
@@ -75,14 +75,14 @@
     <script src="../dist/er-canvas.umd.js"></script>
     <script type="module">
       import * as Y from 'https://cdn.jsdelivr.net/npm/yjs@13.6.12/+esm';
-      import { WebrtcProvider } from 'https://cdn.jsdelivr.net/npm/y-webrtc@10.3.8/+esm';
+      import { WebrtcProvider } from 'https://cdn.jsdelivr.net/npm/y-webrtc@10.3.0/+esm';
 
       const { ERCanvas, createYjsSyncPlugin } = ERCanvasLib;
 
       const ROOM_NAME = 'er-canvas-collaborative-example';
       const doc = new Y.Doc();
       const provider = new WebrtcProvider(ROOM_NAME, doc, {
-        signaling: ['wss://signaling.yjs.dev'],
+        signaling: ['ws://localhost:4444'],
       });
 
       const statusEl = document.getElementById('status');


### PR DESCRIPTION
## Summary
- add a collaborative docker-compose file that runs the static ER canvas demo alongside a local signaling server
- provide a Dockerfile for the signaling container that installs y-webrtc 10.3.0
- point collaborative.html at the local signaling server and pin the client import to y-webrtc 10.3.0

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6140673208324ae08b7c187ae804a